### PR TITLE
Fix bug in javascript

### DIFF
--- a/data/_static/RGBsocket.js
+++ b/data/_static/RGBsocket.js
@@ -7,9 +7,7 @@ let moonColor // name of our color chooser
 let webrgb // current color in #rrggbb format
 let savedColor // for watching if save preference should be enabled.
 let rainbowEnable = false
-let location
-let WebSocket
-const connection = new WebSocket('ws://' + location.hostname + ':81/', ['arduino'])
+const connection = new WebSocket('ws://' + location.hostname + ':81/', ['arduino']) // eslint-disable-line no-undef
 
 window.onbeforeunload = function () {
   connection.onclose = function () {} // disable onclose handler first


### PR DESCRIPTION
TYhis fixes a bug I accidentally introduced, when trying to make "standard", the JavaScript linter happy. It helped my find bugs, but is not made with vanilla javascript in mind, as with **all** other javascript linters I have encountered it assumes you are using `node`, not JS in an HTML webpage.

I would love a vanilla JavaScript linter, but the only I have found yet are ancient perl scripts.